### PR TITLE
Updating HFSM2 from 1.8.0 to 1.11.2 caused compiler notes, when using gcc

### DIFF
--- a/include/hfsm2/machine.hpp
+++ b/include/hfsm2/machine.hpp
@@ -2342,7 +2342,7 @@ private:
 	HFSM2_CONSTEXPR(11)	Index limit()									const noexcept	{ return CAPACITY;					}
 
 private:
-	Item _items[CAPACITY];
+	Item _items[CAPACITY] {};
 };
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Tried to upgrade HFSM2 in our project from version 1.8.0 to 1.11.2, and received a number of compiler notes, concerning a missing default constructor and "the implicitly-defined constructor does not initialize" StaticArrayT::_items (see below). 

These notes may not have any detrimental effects on the output, but this pull request adds initialisation to the _items declaration. This removes the notes from my compiler output.

`
hfsm2/machine.hpp: In instantiation of ‘constexpr void hfsm2::detail::R_<TConfig, TApex>::initialEnter() [with TConfig = hfsm2::detail::G_<5, StateContext&, hfsm2::Automatic, 4, 65535, void>; TApex = hfsm2::detail::CI_<(hfsm2::detail::Strategy)0, void, Idle, Starting, Running, Stopping>]’:
hfsm2/machine.hpp:14053:15:   required from ‘constexpr hfsm2::detail::RV_<hfsm2::detail::G_<NFeatureTag, TContext, TActivation, NSubstitutionLimit, NTaskCapacity, TPayload>, TApex>::RV_(typename hfsm2::detail::RV_<hfsm2::detail::G_<NFeatureTag, TContext, TActivation, NSubstitutionLimit, NTaskCapacity, TPayload>, TApex>::Base::Context&) [with short unsigned int NFeatureTag = 5; TContext = StateContext&; TActivation = hfsm2::Automatic; short unsigned int NSubstitutionLimit = 4; short unsigned int NTaskCapacity = 65535; TPayload = void; TApex = hfsm2::detail::CI_<(hfsm2::detail::Strategy)0, void, Idle, Starting, Running, Stopping>; typename hfsm2::detail::RV_<hfsm2::detail::G_<NFeatureTag, TContext, TActivation, NSubstitutionLimit, NTaskCapacity, TPayload>, TApex>::Base::Context = StateContext&]’
hfsm2/machine.hpp:14419:14:   required from ‘constexpr hfsm2::detail::RC_<hfsm2::detail::G_<NFeatureTag, TContext&, TActivation, NSubstitutionLimit, NTaskCapacity, TPayload>, TApex>::RC_(typename hfsm2::detail::RC_<hfsm2::detail::G_<NFeatureTag, TContext&, TActivation, NSubstitutionLimit, NTaskCapacity, TPayload>, TApex>::Base::Context) [with short unsigned int NFeatureTag = 5; TContext = StateContext; TActivation = hfsm2::Automatic; short unsigned int NSubstitutionLimit = 4; short unsigned int NTaskCapacity = 65535; TPayload = void; TApex = hfsm2::detail::CI_<(hfsm2::detail::Strategy)0, void, Idle, Starting, Running, Stopping>; typename hfsm2::detail::RC_<hfsm2::detail::G_<NFeatureTag, TContext&, TActivation, NSubstitutionLimit, NTaskCapacity, TPayload>, TApex>::Base::Context = StateContext&]’
hfsm2/machine.hpp:14666:14:   required from here
hfsm2/machine.hpp:5013:8: note: ‘using RegistryBackUp = using BackUp = struct hfsm2::detail::BackUpT<hfsm2::detail::RegistryT<hfsm2::detail::ArgsT<StateContext&, hfsm2::detail::G_<5, StateContext&, hfsm2::Automatic, 4, 65535, void>, hfsm2::detail::TL_<void, Idle, Starting, Running, Stopping>, hfsm2::detail::TL_<void>, 1, 0, 0, 4, 8, void> > >’ {aka ‘struct hfsm2::detail::BackUpT<hfsm2::detail::RegistryT<hfsm2::detail::ArgsT<StateContext&, hfsm2::detail::G_<5, StateContext&, hfsm2::Automatic, 4, 65535, void>, hfsm2::detail::TL_<void, Idle, Starting, Running, Stopping>, hfsm2::detail::TL_<void>, 1, 0, 0, 4, 8, void> > >’} has no user-provided default constructor
 struct BackUpT final {
        ^~~~~~~
hfsm2/machine.hpp:2293:22: note: and the implicitly-defined constructor does not initialize ‘hfsm2::detail::StaticArrayT<unsigned char, 1>::Item hfsm2::detail::StaticArrayT<unsigned char, 1>::_items [1]’
  Item _items[CAPACITY];
`