### PR TITLE
Reworked cmake to enable library linking, tests, examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,106 @@
 cmake_minimum_required(VERSION 3.5)
 
-find_program(CCACHE_PROGRAM ccache)
-if(CCACHE_PROGRAM)
-	message(STATUS "Found ccache in ${CCACHE_PROGRAM}")
-	set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+project(hfsm2 VERSION 2.7.0 LANGUAGES CXX)
+
+# Create an interface library (header-only)
+add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+# Set include directories for users of this library
+target_include_directories(${PROJECT_NAME}
+		INTERFACE
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+		$<INSTALL_INTERFACE:include>
+)
+
+# Set C++11 requirement for users of this library
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
+
+# Install the library
+install(TARGETS ${PROJECT_NAME}
+		EXPORT ${PROJECT_NAME}Targets
+		INCLUDES DESTINATION include
+)
+
+# Install the headers
+install(DIRECTORY include/ DESTINATION include)
+
+# Export the targets
+export(EXPORT ${PROJECT_NAME}Targets
+		FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake"
+		NAMESPACE ${PROJECT_NAME}::
+)
+
+# Create and install package configuration files
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+		VERSION ${PROJECT_VERSION}
+		COMPATIBILITY SameMajorVersion
+)
+
+# Simple config file approach (no template required)
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+		"include(CMakeFindDependencyMacro)
+include(\"\${CMAKE_CURRENT_LIST_DIR}/${PROJECT_NAME}Targets.cmake\")
+")
+
+# Install the configuration files
+install(FILES
+		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+		DESTINATION lib/cmake/${PROJECT_NAME}
+)
+
+install(EXPORT ${PROJECT_NAME}Targets
+		FILE ${PROJECT_NAME}Targets.cmake
+		NAMESPACE ${PROJECT_NAME}::
+		DESTINATION lib/cmake/${PROJECT_NAME}
+)
+
+# Testing section
+option(HFSM2_BUILD_TESTS "Build the HFSM2 tests" OFF)
+if(HFSM2_BUILD_TESTS)
+	enable_testing()
+
+	file(GLOB TEST_SOURCE_FILES "test/*.cpp" "test/shared/*.cpp")
+	add_executable(${PROJECT_NAME}_test ${TEST_SOURCE_FILES})
+
+	target_link_libraries(${PROJECT_NAME}_test PRIVATE ${PROJECT_NAME})
+
+	target_include_directories(${PROJECT_NAME}_test PRIVATE
+			"${CMAKE_CURRENT_SOURCE_DIR}/development"
+			"${CMAKE_CURRENT_SOURCE_DIR}/external")
+
+	if(MSVC)
+		target_compile_options(${PROJECT_NAME}_test PRIVATE /W4 /WX)
+	else()
+		target_compile_options(${PROJECT_NAME}_test PRIVATE -Werror -Wall -Wextra -Wpedantic -Wshadow -Wold-style-cast)
+	endif()
+
+	add_test(NAME ${PROJECT_NAME}_test COMMAND ${PROJECT_NAME}_test)
+
+	add_custom_command(TARGET ${PROJECT_NAME}_test
+			POST_BUILD
+			COMMAND ${PROJECT_NAME}_test)
 endif()
 
-project(hfsm2_test)
+# Examples section
+option(HFSM2_BUILD_EXAMPLES "Build the examples" OFF)
+if(HFSM2_BUILD_EXAMPLES)
+	# Check if examples directory exists
+	if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/examples")
+		# Get all subdirectories in examples folder
+		file(GLOB EXAMPLE_DIRS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/examples" "${CMAKE_CURRENT_SOURCE_DIR}/examples/*")
 
-file(GLOB SOURCE_FILES "test/*.cpp" "test/shared/*.cpp")
-add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-
-target_include_directories(${PROJECT_NAME} PRIVATE
-	"${CMAKE_CURRENT_LIST_DIR}/development"
-	"${CMAKE_CURRENT_LIST_DIR}/external"
-	"${CMAKE_CURRENT_LIST_DIR}/include")
-
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
-
-if(MSVC)
-	target_compile_options(${PROJECT_NAME} PRIVATE /W4 /WX)
-else()
-	target_compile_options(${PROJECT_NAME} PRIVATE -Werror -Wall -Wextra -Wpedantic -Wshadow -Wold-style-cast)
+		foreach(EXAMPLE_DIR ${EXAMPLE_DIRS})
+			# Check if the subdirectory contains a CMakeLists.txt
+			if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/examples/${EXAMPLE_DIR}/CMakeLists.txt")
+				message(STATUS "Adding example: ${EXAMPLE_DIR}")
+				add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/examples/${EXAMPLE_DIR}")
+			endif()
+		endforeach()
+	else()
+		message(STATUS "Examples directory not found, skipping examples")
+	endif()
 endif()
-
-add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
-
-add_custom_command(TARGET ${PROJECT_NAME}
-				   POST_BUILD
-				   COMMAND ${PROJECT_NAME})

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,23 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "debug",
+      "displayName": "Debug",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "HFSM2_BUILD_TESTS": "ON",
+        "HFSM2_BUILD_EXAMPLES": "ON"
+      }
+    },
+    {
+      "name": "release",
+      "displayName": "Release",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ]
+}

--- a/examples/advanced_event_handling/CMakeLists.txt
+++ b/examples/advanced_event_handling/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(advanced_event_handling)
+get_filename_component(EXAMPLE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${EXAMPLE_NAME}_example)
 
 file(GLOB SOURCE_FILES "*.cpp")
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-	"${CMAKE_CURRENT_LIST_DIR}/../../include")
+target_link_libraries(${PROJECT_NAME} PRIVATE hfsm2)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 

--- a/examples/basic_audio_player/CMakeLists.txt
+++ b/examples/basic_audio_player/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(basic_audio_player)
+get_filename_component(EXAMPLE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${EXAMPLE_NAME}_example)
 
 file(GLOB SOURCE_FILES "*.cpp")
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-	"${CMAKE_CURRENT_LIST_DIR}/../../include")
+target_link_libraries(${PROJECT_NAME} PRIVATE hfsm2)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 

--- a/examples/basic_traffic_light/CMakeLists.txt
+++ b/examples/basic_traffic_light/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(basic_traffic_light)
+get_filename_component(EXAMPLE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${EXAMPLE_NAME}_example)
 
 file(GLOB SOURCE_FILES "*.cpp")
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-	"${CMAKE_CURRENT_LIST_DIR}/../../include")
+target_link_libraries(${PROJECT_NAME} PRIVATE hfsm2)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 

--- a/examples/calculator/CMakeLists.txt
+++ b/examples/calculator/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(calculator)
+get_filename_component(EXAMPLE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${EXAMPLE_NAME}_example)
 
 file(GLOB SOURCE_FILES "*.cpp")
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-	"${CMAKE_CURRENT_LIST_DIR}/../../include")
+target_link_libraries(${PROJECT_NAME} PRIVATE hfsm2)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 

--- a/examples/debug_logger_interface/CMakeLists.txt
+++ b/examples/debug_logger_interface/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(debug_logger_interface)
+get_filename_component(EXAMPLE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${EXAMPLE_NAME}_example)
 
 file(GLOB SOURCE_FILES "*.cpp")
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-	"${CMAKE_CURRENT_LIST_DIR}/../../include")
+target_link_libraries(${PROJECT_NAME} PRIVATE hfsm2)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 

--- a/examples/temp/CMakeLists.txt
+++ b/examples/temp/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(temp)
+get_filename_component(EXAMPLE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${EXAMPLE_NAME}_example)
 
 file(GLOB SOURCE_FILES "*.cpp")
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-	"${CMAKE_CURRENT_LIST_DIR}/../../include")
+target_link_libraries(${PROJECT_NAME} PRIVATE hfsm2)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 


### PR DESCRIPTION
Description originally from https://github.com/andrew-gresyk/HFSM2/pull/110 by https://github.com/Niproblema:

Enabled cmake installation through 

```
mkdir build-debug && cd build-debug
cmake ..
sudo cmake --install .
```

Include in projects 
```
#include <hfsm2/machine.hpp>
```

Uninstall 
```
sudo xargs rm < install_manifest.txt
```

This will allow me to add the library to the VCPKG and enable usage throgh
```
    find_package(hfsm2 CONFIG REQUIRED)
    target_link_libraries(main PRIVATE hfsm2::hfsm2)
```

I also reworked cmakes for examples and tests a bit;
 - I added `debug` and `release` presets, see `CMakePresets.json`
 - debug preset has enabled tests and examples by default, so IDE correctly enables all targets

![image](https://github.com/user-attachments/assets/110cfc96-5718-46eb-a0d4-78e2ef9a9609)


I incremented the version to 2.7.0 in cmake file and nothing else.